### PR TITLE
Drop suffix from configfile in readme file

### DIFF
--- a/debian/README.Debian
+++ b/debian/README.Debian
@@ -10,7 +10,7 @@ http://syslinux.zytor.com/wiki/index.php/MEMDISK if you have booting
 problems.
 
 If you want to change the path were images are dropped adapt $IMAGES in
-/etc/default/grub-imageboot.conf.
+/etc/default/grub-imageboot.
 
 If you need special options to boot your images see $IMAGEOPTS and
-$ISOOPTS in /etc/default/grub-imageboot.conf.
+$ISOOPTS in /etc/default/grub-imageboot.


### PR DESCRIPTION
The suffix of the config file was removed by 77050ade9fc5c9c29c53e4bdb828cd9754641e79

But it is still mentioned in the readme file.

The pull request removes the conf suffix in the readme file.

Fix https://github.com/formorer/grub-imageboot/issues/3